### PR TITLE
Signed sandboxed app on Mac Os X does not find printers

### DIFF
--- a/src/java.desktop/unix/classes/sun/print/CUPSPrinter.java
+++ b/src/java.desktop/unix/classes/sun/print/CUPSPrinter.java
@@ -51,7 +51,7 @@ public class CUPSPrinter  {
     private static final String debugPrefix = "CUPSPrinter>> ";
     private static final double PRINTER_DPI = 72.0;
     private boolean initialized;
-    private static native String getCupsServer(boolean keepOriginal);
+    private static native String getCupsServer();
     private static native int getCupsPort();
     private static native String getCupsDefaultPrinter();
     private static native String[] getCupsDefaultPrinters();
@@ -97,11 +97,12 @@ public class CUPSPrinter  {
             });
         libFound = initIDs();
         if (libFound) {
-           cupsServer = getCupsServer(false);
+           cupsOriginalServer = getCupsServer();
+           // Is this a local domain socket?
+           boolean isDomainSocket = cupsOriginalServer != null
+                   && cupsOriginalServer.startsWith("/");
+           cupsServer = isDomainSocket ? "localhost" : cupsOriginalServer;
            cupsPort = getCupsPort();
-           if (isSandbox) {
-               cupsOriginalServer = getCupsServer(true);
-           }
         }
     }
 
@@ -454,6 +455,9 @@ public class CUPSPrinter  {
 
     }
 
+    /**
+     * Get list of all CUPS printers using cups functions.
+     */
     static String[] getAllLocalPrinters() {
         return getCupsDefaultPrinters();
     }

--- a/src/java.desktop/unix/classes/sun/print/CUPSPrinter.java
+++ b/src/java.desktop/unix/classes/sun/print/CUPSPrinter.java
@@ -95,7 +95,7 @@ public class CUPSPrinter  {
         if (libFound) {
            cupsServer = getCupsServer();
            // Is this a local domain socket pathname?
-           if (cupsServer.startsWith("/")) {
+           if (cupsServer != null && cupsServer.startsWith("/")) {
                if (isSandboxedApp()) {
                    domainSocketPathname = cupsServer;
                }

--- a/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
@@ -278,23 +278,33 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
               "Exception getting default printer : " + t);
         }
         if (CUPSPrinter.isCupsRunning()) {
-            try {
-                printerURIs = CUPSPrinter.getAllPrinters();
-                IPPPrintService.debug_println("CUPS URIs = " + printerURIs);
-                if (printerURIs != null) {
-                    for (int p = 0; p < printerURIs.length; p++) {
-                       IPPPrintService.debug_println("URI="+printerURIs[p]);
-                    }
+            if(CUPSPrinter.useDomainSocketPathname()) {
+                printers = CUPSPrinter.getAllLocalPrinters();
+                printerURIs = new String[printers.length];
+                for (int p = 0; p < printers.length; p++) {
+                    printerURIs[p] = String.format("ipp://%s:%d/printers/%s",
+                            CUPSPrinter.getServer(), CUPSPrinter.getPort(), printers[p]);
+                    IPPPrintService.debug_println("URI="+printerURIs[p]);
                 }
-            } catch (Throwable t) {
-            IPPPrintService.debug_println(debugPrefix+
-              "Exception getting all CUPS printers : " + t);
-            }
-            if ((printerURIs != null) && (printerURIs.length > 0)) {
-                printers = new String[printerURIs.length];
-                for (int i=0; i<printerURIs.length; i++) {
-                    int lastIndex = printerURIs[i].lastIndexOf("/");
-                    printers[i] = printerURIs[i].substring(lastIndex+1);
+            } else {
+                try {
+                    printerURIs = CUPSPrinter.getAllPrinters();
+                    IPPPrintService.debug_println("CUPS URIs = " + printerURIs);
+                    if (printerURIs != null) {
+                        for (int p = 0; p < printerURIs.length; p++) {
+                           IPPPrintService.debug_println("URI="+printerURIs[p]);
+                        }
+                    }
+                } catch (Throwable t) {
+                IPPPrintService.debug_println(debugPrefix+
+                  "Exception getting all CUPS printers : " + t);
+                }
+                if ((printerURIs != null) && (printerURIs.length > 0)) {
+                    printers = new String[printerURIs.length];
+                    for (int i=0; i<printerURIs.length; i++) {
+                        int lastIndex = printerURIs[i].lastIndexOf("/");
+                        printers[i] = printerURIs[i].substring(lastIndex+1);
+                    }
                 }
             }
         } else {

--- a/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
@@ -278,33 +278,23 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
               "Exception getting default printer : " + t);
         }
         if (CUPSPrinter.isCupsRunning()) {
-            if(CUPSPrinter.useDomainSocketPathname()) {
-                printers = CUPSPrinter.getAllLocalPrinters();
-                printerURIs = new String[printers.length];
-                for (int p = 0; p < printers.length; p++) {
-                    printerURIs[p] = String.format("ipp://%s:%d/printers/%s",
-                            CUPSPrinter.getServer(), CUPSPrinter.getPort(), printers[p]);
-                    IPPPrintService.debug_println("URI="+printerURIs[p]);
-                }
-            } else {
-                try {
-                    printerURIs = CUPSPrinter.getAllPrinters();
-                    IPPPrintService.debug_println("CUPS URIs = " + printerURIs);
-                    if (printerURIs != null) {
-                        for (int p = 0; p < printerURIs.length; p++) {
-                           IPPPrintService.debug_println("URI="+printerURIs[p]);
-                        }
+            try {
+                printerURIs = CUPSPrinter.getAllPrinters();
+                IPPPrintService.debug_println("CUPS URIs = " + printerURIs);
+                if (printerURIs != null) {
+                    for (int p = 0; p < printerURIs.length; p++) {
+                       IPPPrintService.debug_println("URI="+printerURIs[p]);
                     }
-                } catch (Throwable t) {
-                IPPPrintService.debug_println(debugPrefix+
-                  "Exception getting all CUPS printers : " + t);
                 }
-                if ((printerURIs != null) && (printerURIs.length > 0)) {
-                    printers = new String[printerURIs.length];
-                    for (int i=0; i<printerURIs.length; i++) {
-                        int lastIndex = printerURIs[i].lastIndexOf("/");
-                        printers[i] = printerURIs[i].substring(lastIndex+1);
-                    }
+            } catch (Throwable t) {
+            IPPPrintService.debug_println(debugPrefix+
+              "Exception getting all CUPS printers : " + t);
+            }
+            if ((printerURIs != null) && (printerURIs.length > 0)) {
+                printers = new String[printerURIs.length];
+                for (int i=0; i<printerURIs.length; i++) {
+                    int lastIndex = printerURIs[i].lastIndexOf("/");
+                    printers[i] = printerURIs[i].substring(lastIndex+1);
                 }
             }
         } else {

--- a/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
+++ b/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
@@ -232,6 +232,10 @@ Java_sun_print_CUPSPrinter_getCupsDefaultPrinters(JNIEnv *env,
 
     num_dests = j2d_cupsGetDests(&dests);
 
+    if (dests == NULL) {
+        return NULL;
+    }
+
     nameArray = (*env)->NewObjectArray(env, num_dests, cls, NULL);
     if (nameArray == NULL) {
         j2d_cupsFreeDests(num_dests, dests);
@@ -241,7 +245,7 @@ Java_sun_print_CUPSPrinter_getCupsDefaultPrinters(JNIEnv *env,
         return NULL;
     }
 
-    for (i = 0; dests != NULL && i < num_dests; i++) {
+    for (i = 0; i < num_dests; i++) {
             utf_str = JNU_NewStringPlatform(env, dests[i].name);
             if (utf_str == NULL) {
                 j2d_cupsFreeDests(num_dests, dests);

--- a/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
+++ b/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
@@ -167,13 +167,14 @@ Java_sun_print_CUPSPrinter_initIDs(JNIEnv *env,
  */
 JNIEXPORT jstring JNICALL
 Java_sun_print_CUPSPrinter_getCupsServer(JNIEnv *env,
-                                         jobject printObj)
+                                         jobject printObj,
+                                         jboolean keepOriginal)
 {
     jstring cServer = NULL;
     const char* server = j2d_cupsServer();
     if (server != NULL) {
         // Is this a local domain socket?
-        if (strncmp(server, "/", 1) == 0) {
+        if (keepOriginal == JNI_FALSE && strncmp(server, "/", 1) == 0) {
             cServer = JNU_NewStringPlatform(env, "localhost");
         } else {
             cServer = JNU_NewStringPlatform(env, server);
@@ -217,6 +218,49 @@ Java_sun_print_CUPSPrinter_getCupsDefaultPrinter(JNIEnv *env,
     }
     j2d_cupsFreeDests(num_dests, dests);
     return cDefPrinter;
+}
+
+/*
+ * Returns list of default local printers
+ */
+JNIEXPORT jobjectArray JNICALL
+Java_sun_print_CUPSPrinter_getCupsDefaultPrinters(JNIEnv *env,
+                                                        jobject printObj)
+{
+    cups_dest_t *dests;
+    int i, num_dests;
+    jstring utf_str;
+    jclass cls;
+    jobjectArray nameArray = NULL;
+
+    cls = (*env)->FindClass(env, "java/lang/String");
+    CHECK_NULL_RETURN(cls, NULL);
+
+    num_dests = j2d_cupsGetDests(&dests);
+
+    nameArray = (*env)->NewObjectArray(env, num_dests, cls, NULL);
+    if (nameArray == NULL) {
+        j2d_cupsFreeDests(num_dests, dests);
+        DPRINTF("CUPSfuncs::bad alloc new array\n", "")
+        (*env)->ExceptionClear(env);
+        JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+        return NULL;
+    }
+
+    for (i = 0; dests != NULL && i < num_dests; i++) {
+            utf_str = JNU_NewStringPlatform(env, dests[i].name);
+            if (utf_str == NULL) {
+                j2d_cupsFreeDests(num_dests, dests);
+                DPRINTF("CUPSfuncs::bad alloc new string ->name\n", "")
+                JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+                return NULL;
+            }
+            (*env)->SetObjectArrayElement(env, nameArray, i, utf_str);
+            (*env)->DeleteLocalRef(env, utf_str);
+    }
+
+    j2d_cupsFreeDests(num_dests, dests);
+    return nameArray;
 }
 
 /*

--- a/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
+++ b/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
@@ -167,18 +167,12 @@ Java_sun_print_CUPSPrinter_initIDs(JNIEnv *env,
  */
 JNIEXPORT jstring JNICALL
 Java_sun_print_CUPSPrinter_getCupsServer(JNIEnv *env,
-                                         jobject printObj,
-                                         jboolean keepOriginal)
+                                         jobject printObj)
 {
     jstring cServer = NULL;
     const char* server = j2d_cupsServer();
     if (server != NULL) {
-        // Is this a local domain socket?
-        if (keepOriginal == JNI_FALSE && strncmp(server, "/", 1) == 0) {
-            cServer = JNU_NewStringPlatform(env, "localhost");
-        } else {
-            cServer = JNU_NewStringPlatform(env, server);
-        }
+        cServer = JNU_NewStringPlatform(env, server);
     }
     return cServer;
 }


### PR DESCRIPTION
Apple block access to print service on localhost:631 for signed sandboxed app and suggests to use cups functions instead.

See the discussion on 2d-dev mail list:
https://mail.openjdk.java.net/pipermail/2d-dev/2017-June/008375.html
https://mail.openjdk.java.net/pipermail/2d-dev/2017-July/008418.html
```
I've submitted a DTS incident to Apple and a friend there has followed-up. 
Their unofficial position is that java should be connecting to the cups interface returned
by the cupsServer() function and not changing the interface string to "localhost". 
Security changes in 10.12.4 reject the TCP connection which they say confuses
network-client access with print access.  They don't seem interested in loosening that change.
```

The proposed solution returns all available printers using cupsGetDests() function if an application is running in sandbox on MacOsX and cupsServer() function returns domain socket pathname like`/private/var/run/cupsd` . 

The canConnect() call is updated to use original domain socket pathname.